### PR TITLE
Use `unscoped` in processing column assignment.

### DIFF
--- a/lib/delayed_paperclip.rb
+++ b/lib/delayed_paperclip.rb
@@ -92,6 +92,8 @@ module DelayedPaperclip
 
     # setting each inididual NAME_processing to true, skipping the ActiveModel dirty setter
     # Then immediately push the state to the database
+    # Using +unscoped+ here as we're directly looking up by ID and don't want to get stuck
+    # on any +default_scope+ defined.
     def mark_enqueue_delayed_processing
       unless @_enqued_for_processing_with_processing.blank? # catches nil and empty arrays
         updates = @_enqued_for_processing_with_processing.collect{|n| "#{n}_processing = :true" }.join(", ")

--- a/lib/delayed_paperclip/attachment.rb
+++ b/lib/delayed_paperclip/attachment.rb
@@ -78,12 +78,13 @@ module DelayedPaperclip
 
     private
 
+    # Update processing to false. Using +unscoped+ here as we do not want to get hung up on any
+    # +default_scope+ defined.
     def update_processing_column
       if instance.respond_to?(:"#{name}_processing?")
         instance.send("#{name}_processing=", false)
         instance.class.unscoped.where(instance.class.primary_key => instance.id).update_all({ "#{name}_processing" => false })
       end
     end
-
   end
 end


### PR DESCRIPTION
Using unscoped will prevent skipping any processing column assignment which may come up due to a default scope being used on the model.